### PR TITLE
Migrate to Swift Issue Reporting 2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,8 +50,8 @@ let package = Package(
 			.upToNextMinor(from: "0.2.0")
 		),
 		.package(
-			url: "https://github.com/pointfreeco/xctest-dynamic-overlay.git",
-			.upToNextMajor(from: "1.8.0")
+			url: "https://github.com/pointfreeco/swift-issue-reporting.git",
+			.upToNextMajor(from: "2.0.0")
 		),
 	],
 	targets: [
@@ -72,7 +72,7 @@ let package = Package(
 				),
 				.product(
 					name: "IssueReporting",
-					package: "xctest-dynamic-overlay"
+					package: "swift-issue-reporting"
 				),
 			]
 		),

--- a/Package@swift-5.9.swift
+++ b/Package@swift-5.9.swift
@@ -50,8 +50,8 @@ let package = Package(
 			.upToNextMinor(from: "0.2.0")
 		),
 		.package(
-			url: "https://github.com/pointfreeco/xctest-dynamic-overlay.git",
-			.upToNextMajor(from: "1.8.0")
+			url: "https://github.com/pointfreeco/swift-issue-reporting.git",
+			.upToNextMajor(from: "2.0.0")
 		),
 	],
 	targets: [
@@ -72,7 +72,7 @@ let package = Package(
 				),
 				.product(
 					name: "IssueReporting",
-					package: "xctest-dynamic-overlay"
+					package: "swift-issue-reporting"
 				),
 			]
 		),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -50,8 +50,8 @@ let package = Package(
 			.upToNextMinor(from: "0.2.0")
 		),
 		.package(
-			url: "https://github.com/pointfreeco/xctest-dynamic-overlay.git",
-			.upToNextMajor(from: "1.8.0")
+			url: "https://github.com/pointfreeco/swift-issue-reporting.git",
+			.upToNextMajor(from: "2.0.0")
 		),
 	],
 	targets: [
@@ -72,7 +72,7 @@ let package = Package(
 				),
 				.product(
 					name: "IssueReporting",
-					package: "xctest-dynamic-overlay"
+					package: "swift-issue-reporting"
 				),
 			]
 		),


### PR DESCRIPTION
## Summary

- replace the legacy `xctest-dynamic-overlay` package URL with `swift-issue-reporting`
- require IssueReporting 2.0.0
- update package identities in all supported manifest variants

## Validation

- IssueReporting 2.0.0 resolves and the package builds
- existing known-issue tests fail under the installed Xcode 27 beta; no migration-specific compiler failures were found